### PR TITLE
fix override config parameter issue by using UNSET_VALUE

### DIFF
--- a/lib/vagrant-mutagen/config.rb
+++ b/lib/vagrant-mutagen/config.rb
@@ -7,7 +7,11 @@ module VagrantPlugins
         attr_accessor :orchestrate
 
         def initialize
-          @orchestrate = false
+          @orchestrate = UNSET_VALUE
+        end
+
+        def finalize!
+          @orchestrate = false if @orchestrate == UNSET_VALUE
         end
     end
   end


### PR DESCRIPTION
Hi,

When we use "override" of config parameter, for example as follows:

```
Vagrant.configure("2") do |config|
  config.vagrant.plugins = ["vagrant-aws", "vagrant-mutagen"]
  config.vm.hostname = "host1"
  config.vm.box = "dummy"
  config.mutagen.orchestrate = true

  config.vm.provider :aws do |aws, override|
    override.ssh.username = "ubuntu"
  end
end
```

orchestration of mutagen seems to be always disabled.

This is probably because "override" parameter is initialized as new config object ("orchestrate" is initialized as false) and merged to global config object ("orchestrate" is overwritten as false).

This patch will fix the issue.

See following doc for additional info:
https://www.vagrantup.com/docs/plugins/configuration.html#implementation