### PR TITLE
Fix/cannot edit entries of ssh config

### DIFF
--- a/lib/vagrant-mutagen/Mutagen.rb
+++ b/lib/vagrant-mutagen/Mutagen.rb
@@ -3,6 +3,9 @@ require 'yaml'
 module VagrantPlugins
   module Mutagen
     module Mutagen
+      DISCARD_STDOUT = Vagrant::Util::Platform.windows? ? '>nul'  : '>/dev/null'
+      DISCARD_STDERR = Vagrant::Util::Platform.windows? ? '2>nul' : '2>/dev/null'
+
       if ENV['VAGRANT_MUTAGEN_SSH_CONFIG_PATH']
         @@ssh_user_config_path = ENV['VAGRANT_MUTAGEN_SSH_CONFIG_PATH']
       else
@@ -159,7 +162,7 @@ module VagrantPlugins
 
       def startOrchestration()
         daemonCommand = "mutagen daemon start"
-        projectStartedCommand = "mutagen project list >/dev/null 2>/dev/null"
+        projectStartedCommand = "mutagen project list #{DISCARD_STDOUT} #{DISCARD_STDERR}"
         projectStartCommand = "mutagen project start"
         projectStatusCommand = "mutagen project list"
         if !system(daemonCommand)
@@ -175,9 +178,9 @@ module VagrantPlugins
       end
 
       def terminateOrchestration()
-        projectStartedCommand = "mutagen project list >/dev/null 2>/dev/null"
+        projectStartedCommand = "mutagen project list #{DISCARD_STDOUT} #{DISCARD_STDERR}"
         projectTerminateCommand = "mutagen project terminate"
-        projectStatusCommand = "mutagen project list 2>/dev/null"
+        projectStatusCommand = "mutagen project list #{DISCARD_STDERR}"
         if system(projectStartedCommand) # mutagen project list returns 1 on error when no project is started
           @ui.info "[vagrant-mutagen] Stopping mutagen project orchestration"
           if !system(projectTerminateCommand)

--- a/lib/vagrant-mutagen/Mutagen.rb
+++ b/lib/vagrant-mutagen/Mutagen.rb
@@ -52,10 +52,12 @@ module VagrantPlugins
           uuid = @machine.id || @machine.config.mutagen.id
           tmpPath = File.join(Dir.tmpdir, 'hosts-' + uuid + '.cmd')
           File.open(tmpPath, "w") do |tmpFile|
-          tmpFile.puts(">>\"#{@@ssh_user_config_path}\" echo #{content}")
+            cmd_content = content.lines.map {|line| ">>\"#{@@ssh_user_config_path}\" echo #{line}" }.join
+            tmpFile.puts(cmd_content)
           end
           sudo(tmpPath)
-          File.delete(tmpPath)
+          #[TODO] sudo を実行するのを待たずにファイルが削除されるのか、delete すると cmd が実行されない
+          # File.delete(tmpPath)
         else
           content = "\n" + content + "\n"
           hostsFile = File.open(@@ssh_user_config_path, "a")

--- a/lib/vagrant-mutagen/Mutagen.rb
+++ b/lib/vagrant-mutagen/Mutagen.rb
@@ -22,8 +22,7 @@ module VagrantPlugins
         newconfig = ''
 
         # Read contents of SSH config file
-        file = File.open(@@ssh_user_config_path, "rb")
-        configContents = file.read
+        configContents = File.read(@@ssh_user_config_path)
         # Check for existing entry for hostname in config
         entryPattern = configEntryPattern(hostname, name, uuid)
         if configContents.match(/#{entryPattern}/)
@@ -94,8 +93,7 @@ module VagrantPlugins
           @ui.info "[vagrant-mutagen] No machine id, nothing removed from #@@ssh_user_config_path"
           return
         end
-        file = File.open(@@ssh_user_config_path, "rb")
-        configContents = file.read
+        configContents = File.read(@@ssh_user_config_path)
         uuid = @machine.id || @machine.config.mutagen.id
         hashedId = Digest::MD5.hexdigest(uuid)
         if configContents.match(/#{hashedId}/)

--- a/lib/vagrant-mutagen/Mutagen.rb
+++ b/lib/vagrant-mutagen/Mutagen.rb
@@ -146,6 +146,7 @@ module VagrantPlugins
           sh.ShellExecute(command, args.join(" "), '', 'runas', 0)
           # ShellExecute does not wait for the command to exit.
           sleep 3 if wait
+          return true
         else
           return system("sudo #{command}")
         end

--- a/lib/vagrant-mutagen/Mutagen.rb
+++ b/lib/vagrant-mutagen/Mutagen.rb
@@ -144,8 +144,7 @@ module VagrantPlugins
           command = args.shift
           sh = WIN32OLE.new('Shell.Application')
           sh.ShellExecute(command, args.join(" "), '', 'runas', 0)
-          # ShellExecute does not wait for the command to exit.
-          sleep 3 if wait
+          sleep 3 if wait # Wait a while because ShellExecute does not wait for the command to exit.
           return true
         else
           return system("sudo #{command}")


### PR DESCRIPTION
Hi.

I'm thinking of using the vagrant-mutagen plugin on Windows, but plugin work with unexpected it due to some problems.
This PR solves those problems.

Problems

- Can't add or delete entries in SSH Config file because IO handle is still open
- No entry is added to SSH Config file because the cmd file is deleted before finishes executing
- The cmd file cannot write a multi-line entry to a file

And also, it can now discard standard output and standard error output to avoid error messages "The system cannot find the path specified.".

## Logs and statuses on problem

### vagrant up

```shell
PS V:\vagrant\ubuntu-focal64> vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Checking if box 'ubuntu/focal64' version '20200424.0.0' is up to date...
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2200 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: [vagrant-mutagen] Checking for SSH config entries
==> default: [vagrant-mutagen]   adding entry to SSH config for: focal64
==> default: [vagrant-mutagen] Writing the following config to (C:/Users/tatsu/.ssh/config)
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
==> default: Host focal64
==> default:   HostName 127.0.0.1
==> default:   User vagrant
==> default:   Port 2200
==> default:   UserKnownHostsFile /dev/null
==> default:   StrictHostKeyChecking no
==> default:   PasswordAuthentication no
==> default:   IdentityFile V:/vagrant/ubuntu-focal64/.vagrant/machines/default/virtualbox/private_key
==> default:   IdentitiesOnly yes
==> default:   LogLevel FATAL
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
The system cannot find the path specified.
==> default: [vagrant-mutagen] Starting mutagen project orchestration (config: /mutagen.yml)
Connecting to agent (POSIX)...
Error: unable to create synchronization session (focal64): create failed: unable to connect to beta: unable to connect to endpoint: unable to dial agent endpoint: agent handshake failed with error output:
ssh: Could not resolve hostname focal64: Name or service not known
==> default: [vagrant-mutagen] Failed to start mutagen project (see error above)
Forwarding sessions:
-------------------------------------------------------------------------------
No sessions found
-------------------------------------------------------------------------------

Synchronization sessions:
-------------------------------------------------------------------------------
No sessions found
-------------------------------------------------------------------------------
==> default: Setting hostname...
==> default: Mounting shared folders...
    default: /vagrant => V:/vagrant/ubuntu-focal64
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.
```

Statuses

- VM is started
- No entry are added to `%USERPROFILE%/.ssh/config`
- mutagen project is started (but it cannot sync)

### vagrant reload

```shell
PS V:\vagrant\ubuntu-focal64> vagrant reload
==> default: [vagrant-mutagen] Removing SSH config entry
==> default: Attempting graceful shutdown of VM...
==> default: Checking if box 'ubuntu/focal64' version '20200424.0.0' is up to date...
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2200 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
The system cannot find the path specified.
The system cannot find the path specified.
==> default: [vagrant-mutagen] Checking for SSH config entries
==> default: [vagrant-mutagen]   adding entry to SSH config for: focal64
==> default: [vagrant-mutagen] Writing the following config to (C:/Users/tatsu/.ssh/config)
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
==> default: Host focal64
==> default:   HostName 127.0.0.1
==> default:   User vagrant
==> default:   Port 2200
==> default:   UserKnownHostsFile /dev/null
==> default:   StrictHostKeyChecking no
==> default:   PasswordAuthentication no
==> default:   IdentityFile V:/vagrant/ubuntu-focal64/.vagrant/machines/default/virtualbox/private_key
==> default:   IdentitiesOnly yes
==> default:   LogLevel FATAL
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
The system cannot find the path specified.
==> default: [vagrant-mutagen] Starting mutagen project orchestration (config: /mutagen.yml)
Error: project already running
==> default: [vagrant-mutagen] Failed to start mutagen project (see error above)
Forwarding sessions:
-------------------------------------------------------------------------------
No sessions found
-------------------------------------------------------------------------------

Synchronization sessions:
-------------------------------------------------------------------------------
No sessions found
-------------------------------------------------------------------------------
==> default: Setting hostname...
==> default: Mounting shared folders...
    default: /vagrant => V:/vagrant/ubuntu-focal64
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.
```

Statuses

- VM is reloaded
- No entries are removed from `%USERPROFILE%/.ssh/config` on halting VM, and no entries are added on starting VM
- mutagen project still running on halting VM, and mutagen project fail to start on starting VM start

## Logs and statuses on PR branch

### vagrant up

```shell
PS V:\vagrant\ubuntu-focal64> vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Checking if box 'ubuntu/focal64' version '20200424.0.0' is up to date...
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2200 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: [vagrant-mutagen] Checking for SSH config entries
==> default: [vagrant-mutagen]   adding entry to SSH config for: focal64
==> default: [vagrant-mutagen] Writing the following config to (C:/Users/tatsu/.ssh/config)
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
==> default: Host focal64
==> default:   HostName 127.0.0.1
==> default:   User vagrant
==> default:   Port 2200
==> default:   UserKnownHostsFile /dev/null
==> default:   StrictHostKeyChecking no
==> default:   PasswordAuthentication no
==> default:   IdentityFile V:/vagrant/ubuntu-focal64/.vagrant/machines/default/virtualbox/private_key
==> default:   IdentitiesOnly yes
==> default:   LogLevel FATAL
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
==> default: [vagrant-mutagen] Starting mutagen project orchestration (config: /mutagen.yml)
Created session sync_w6NnLGaReU5hGX13ItmfPYVIMJknyINht4EpfWPFVIs
Forwarding sessions:
-------------------------------------------------------------------------------
No sessions found
-------------------------------------------------------------------------------

Synchronization sessions:
-------------------------------------------------------------------------------
Name: focal64
Identifier: sync_w6NnLGaReU5hGX13ItmfPYVIMJknyINht4EpfWPFVIs
Labels:
        io.mutagen.project: proj_8nmuxClTmxs61OMHiHYFzxZwGIaw9qsHlofpBZbeidM
Alpha:
        URL: ****
        Connection state: Connected
Beta:
        URL: focal64:/home/vagrant/mutagen/tmp
        Connection state: Connected
Status: Watching for changes
-------------------------------------------------------------------------------
==> default: Setting hostname...
==> default: Mounting shared folders...
    default: /vagrant => V:/vagrant/ubuntu-focal64
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.
```

Statuses

- VM is started
- Entry are added to `%USERPROFILE%/.ssh/config`
- mutagen project is started and it successfully sync

### vagrant reload

```shell
PS V:\vagrant\ubuntu-focal64> vagrant reload
==> default: [vagrant-mutagen] Removing SSH config entry
==> default: Attempting graceful shutdown of VM...
==> default: Checking if box 'ubuntu/focal64' version '20200424.0.0' is up to date...
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2200 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: [vagrant-mutagen] Stopping mutagen project orchestration
Error: project not running
==> default: [vagrant-mutagen] Checking for SSH config entries
==> default: [vagrant-mutagen]   adding entry to SSH config for: focal64
==> default: [vagrant-mutagen] Writing the following config to (C:/Users/tatsu/.ssh/config)
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
==> default: Host focal64
==> default:   HostName 127.0.0.1
==> default:   User vagrant
==> default:   Port 2200
==> default:   UserKnownHostsFile /dev/null
==> default:   StrictHostKeyChecking no
==> default:   PasswordAuthentication no
==> default:   IdentityFile V:/vagrant/ubuntu-focal64/.vagrant/machines/default/virtualbox/private_key
==> default:   IdentitiesOnly yes
==> default:   LogLevel FATAL
==> default: # VAGRANT: d48bb6ad9155bbf3050fac8655a13f5d (default) / 95f020a0-5da6-4555-be75-5c9e90d4d3c6
==> default: [vagrant-mutagen] Starting mutagen project orchestration (config: /mutagen.yml)
Created session sync_5HgCft8RgbyRNy7yNaZrmNMEPOgflqpk5bubL2jmmLD
Forwarding sessions:
-------------------------------------------------------------------------------
No sessions found
-------------------------------------------------------------------------------

Synchronization sessions:
-------------------------------------------------------------------------------
Name: focal64
Identifier: sync_5HgCft8RgbyRNy7yNaZrmNMEPOgflqpk5bubL2jmmLD
Labels:
        io.mutagen.project: proj_P8VW3YTYjnBVfRIGIGArbdZjf8YQve6zSnNQNeLjaHi
Alpha:
        URL: D:\usr\DevApp\repos_github2\ryu-sato\vagrant-mutagen
        Connection state: Connected
Beta:
        URL: focal64:/home/vagrant/mutagen/tmp
        Connection state: Connected
Status: Scanning files
-------------------------------------------------------------------------------
==> default: Setting hostname...
==> default: Mounting shared folders...
    default: /vagrant => V:/vagrant/ubuntu-focal64
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.
```

Statuses

- VM is reloaded
- Entry is removed from `%USERPROFILE%/.ssh/config` on halting VM, and entry is added on starting VM
- mutagen project is terminated on halting VM, and mutagen project is started on starting VM start
