### PR TITLE
Fix plugin for vagrant 2.2.14

### DIFF
--- a/lib/vagrant-mutagen/plugin.rb
+++ b/lib/vagrant-mutagen/plugin.rb
@@ -19,8 +19,8 @@ module VagrantPlugins
       end
 
       action_hook(:mutagen, :machine_action_up) do |hook|
-        hook.append(Action::UpdateConfig)
-        hook.append(Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_provision) do |hook|
@@ -50,15 +50,15 @@ module VagrantPlugins
       action_hook(:mutagen, :machine_action_reload) do |hook|
         hook.append(Action::TerminateOrchestration)
         hook.prepend(Action::RemoveConfig)
-        hook.append(Action::UpdateConfig)
-        hook.append(Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_resume) do |hook|
         hook.append(Action::TerminateOrchestration)
         hook.prepend(Action::RemoveConfig)
-        hook.append(Action::UpdateConfig)
-        hook.append(Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
       end
 
       command(:mutagen) do


### PR DESCRIPTION
Hi,

After vagrant 2.2.14 seems they changed the way the plugins are being called. I started having the error below

```
../gems/vagrant-mutagen-0.1.2/lib/vagrant-mutagen/Mutagen.rb:70:in `digest': no implicit conversion of nil into String (TypeError)
```

Running the plugin locally I noted that the `@machine.id` was nil when the plugin was first called.

My first solution was avoiding to update the ssh config entries when the machine id was nil, but it created another problems: 

1. the plugin became very noisy -  the plugin was being called several times during vagrant up. It was listing all the vagrant sessions and trying to update the ssh config entries every call. It seems to be happening in other plugin like mentioned in this thread https://github.com/agiledivider/vagrant-hostsupdater/issues/102#issuecomment-733133677 

2. the machine state - I'm using the docker provider. Even though during the vagrant up the plugin was being called several times, part of them, the machine was in `stopped` state and the id was already available. It was starting the mutagen project but it was failing to start the sessions.

I changed my approach to find a better time to start the plugin, and after WaitForCommunicator action seems a good time. As I understood WaitForCommunicator is triggered when the machine is booted and ready to receive communications.

In my tests, it worked perfectly.