### PR TITLE
Fix action_hook for vagrant 2.2.14

### DIFF
--- a/lib/vagrant-mutagen/Action/RemoveConfig.rb
+++ b/lib/vagrant-mutagen/Action/RemoveConfig.rb
@@ -12,15 +12,9 @@ module VagrantPlugins
 
         def call(env)
           machine_action = env[:machine_action]
-          if machine_action != :destroy || !@machine.id
-            if machine_action != :suspend
-              if machine_action != :halt
-                if mutagen_enabled
-                  @ui.info "[vagrant-mutagen] Removing SSH config entry"
-                  removeConfigEntries
-                end
-              end
-            end
+          if mutagen_enabled
+            @ui.info "[vagrant-mutagen] Checking for removing SSH config entry"
+            removeConfigEntries
           end
           @app.call(env)
         end

--- a/lib/vagrant-mutagen/Action/StartOrchestration.rb
+++ b/lib/vagrant-mutagen/Action/StartOrchestration.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
 
         def call(env)
           if mutagen_enabled
+            @ui.info "[vagrant-mutagen] Checking for activating orchestration"
             startOrchestration
           end
           @app.call(env)

--- a/lib/vagrant-mutagen/Action/TerminateOrchestration.rb
+++ b/lib/vagrant-mutagen/Action/TerminateOrchestration.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
 
         def call(env)
           if mutagen_enabled
+            @ui.info "[vagrant-mutagen] Checking for deactivating orchestration"
             terminateOrchestration
           end
           @app.call(env)

--- a/lib/vagrant-mutagen/Action/UpdateConfig.rb
+++ b/lib/vagrant-mutagen/Action/UpdateConfig.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
 
         def call(env)
           if mutagen_enabled
-            @ui.info "[vagrant-mutagen] Checking for SSH config entries"
+            @ui.info "[vagrant-mutagen] Checking for registing SSH config entry"
             addConfigEntries()
           end
           @app.call(env)

--- a/lib/vagrant-mutagen/Mutagen.rb
+++ b/lib/vagrant-mutagen/Mutagen.rb
@@ -24,12 +24,10 @@ module VagrantPlugins
         # Check for existing entry for hostname in config
         entryPattern = configEntryPattern(hostname, name, uuid)
         if configContents.match(/#{entryPattern}/)
-          @ui.info "[vagrant-mutagen]   updating SSH Config entry for: #{hostname}"
           removeConfigEntries
-        else
-          @ui.info "[vagrant-mutagen]   adding entry to SSH config for: #{hostname}"
         end
 
+        @ui.info "[vagrant-mutagen]   adding entry to SSH config for: #{hostname}"
         # Get SSH config from Vagrant
         newconfig = createConfigEntry(hostname, name, uuid)
         # Append vagrant ssh config to end of file
@@ -92,8 +90,10 @@ module VagrantPlugins
         file = File.open(@@ssh_user_config_path, "rb")
         configContents = file.read
         uuid = @machine.id || @machine.config.mutagen.id
+        hostname = @machine.config.vm.hostname
         hashedId = Digest::MD5.hexdigest(uuid)
         if configContents.match(/#{hashedId}/)
+          @ui.info "[vagrant-mutagen]   removing SSH Config entry for: #{hostname}"
           removeFromConfig
         end
       end
@@ -164,7 +164,7 @@ module VagrantPlugins
           @ui.error "[vagrant-mutagen] Failed to start mutagen daemon"
         end
         if !system(projectStartedCommand) # mutagen project list returns 1 on error when no project is started
-          @ui.info "[vagrant-mutagen] Starting mutagen project orchestration (config: /mutagen.yml)"
+          @ui.info "[vagrant-mutagen]   starting mutagen project orchestration (config: /mutagen.yml)"
           if !system(projectStartCommand)
             @ui.error "[vagrant-mutagen] Failed to start mutagen project (see error above)"
           end
@@ -177,7 +177,7 @@ module VagrantPlugins
         projectTerminateCommand = "mutagen project terminate"
         projectStatusCommand = "mutagen project list 2>/dev/null"
         if system(projectStartedCommand) # mutagen project list returns 1 on error when no project is started
-          @ui.info "[vagrant-mutagen] Stopping mutagen project orchestration"
+          @ui.info "[vagrant-mutagen]   stopping mutagen project orchestration"
           if !system(projectTerminateCommand)
             @ui.error "[vagrant-mutagen] Failed to stop mutagen project (see error above)"
           end

--- a/lib/vagrant-mutagen/plugin.rb
+++ b/lib/vagrant-mutagen/plugin.rb
@@ -19,8 +19,8 @@ module VagrantPlugins
       end
 
       action_hook(:mutagen, :machine_action_up) do |hook|
-        hook.append(Action::UpdateConfig)
-        hook.append(Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
       end
 
       action_hook(:mutagen, :machine_action_provision) do |hook|
@@ -29,36 +29,28 @@ module VagrantPlugins
       end
 
       action_hook(:mutagen, :machine_action_halt) do |hook|
-        hook.append(Action::TerminateOrchestration)
-        hook.append(Action::RemoveConfig)
+        hook.before(Vagrant::Action::Builtin::GracefulHalt, Action::TerminateOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_suspend) do |hook|
-        hook.append(Action::TerminateOrchestration)
-        hook.append(Action::RemoveConfig)
+        hook.prepend(Action::TerminateOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_destroy) do |hook|
-        hook.prepend(Action::CacheConfig)
-      end
-
-      action_hook(:mutagen, :machine_action_destroy) do |hook|
-        hook.append(Action::TerminateOrchestration)
-        hook.append(Action::RemoveConfig)
+        hook.before(Vagrant::Action::Builtin::GracefulHalt, Action::CacheConfig)
+        hook.before(Vagrant::Action::Builtin::GracefulHalt, Action::TerminateOrchestration)
+        hook.after(Vagrant::Action::Builtin::GracefulHalt, Action::RemoveConfig)
       end
 
       action_hook(:mutagen, :machine_action_reload) do |hook|
-        hook.append(Action::TerminateOrchestration)
-        hook.prepend(Action::RemoveConfig)
-        hook.append(Action::UpdateConfig)
-        hook.append(Action::StartOrchestration)
+        hook.before(Vagrant::Action::Builtin::GracefulHalt, Action::TerminateOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
       end
 
       action_hook(:mutagen, :machine_action_resume) do |hook|
-        hook.append(Action::TerminateOrchestration)
-        hook.prepend(Action::RemoveConfig)
-        hook.append(Action::UpdateConfig)
-        hook.append(Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
       end
 
       command(:mutagen) do


### PR DESCRIPTION
This fix is for #8 
This trouble looks to be caused by changing timing to call [vagrant action hooks](https://www.vagrantup.com/docs/plugins/action-hooks) after vagrant 2.2.14
I tried to fix config for action_hook with the following way.

* Avoid `append` hook
* Select a hooked action which looks good timing in builtin actions for `before` `after` hook
* Reverse `after` hook definition order because `after` hook looks to be called order by desc

And, the following some misc fixes be included

* Call RemoveConfig with keeping in step with other actions
* Fix console output
* Quit RemoveConfig on `suspend` and `halt` because I feel we still need ssh config on their timings

This fix works in my environment but I'm hesitating by the following reasons.

* Probably this fix works only for virtualbox
    * I selected a hooked action with refering https://github.com/hashicorp/vagrant/blob/v2.2.14/plugins/providers/virtualbox/action.rb 
    * But, I noticed uncalled actions exists in https://github.com/hashicorp/vagrant/blob/v2.2.14/plugins/providers/docker/action.rb
* Probably my choice hooked actions are private api
* I feel this trouble is vagrant bug
    * I can't find document about hook for developer other than https://www.vagrantup.com/docs/plugins/action-hooks
    * And, it describes `called after the machine has entered the up state`. So, I feel `append` hook is OK
    * But, I can't find the change log or commit of vagrant which causes this trouble.
