### PR TITLE
Fix failure on `vagrant up` -- orchestration attempted before ssh configuration added

### DIFF
--- a/lib/vagrant-mutagen/plugin.rb
+++ b/lib/vagrant-mutagen/plugin.rb
@@ -20,12 +20,12 @@ module VagrantPlugins
 
       action_hook(:mutagen, :machine_action_up) do |hook|
         hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
-        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
+        hook.after(Action::UpdateConfig, Action::StartOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_provision) do |hook|
         hook.before(Vagrant::Action::Builtin::Provision, Action::UpdateConfig)
-        hook.before(Vagrant::Action::Builtin::Provision, Action::StartOrchestration)
+        hook.after(Action::UpdateConfig, Action::StartOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_halt) do |hook|
@@ -51,14 +51,14 @@ module VagrantPlugins
         hook.append(Action::TerminateOrchestration)
         hook.prepend(Action::RemoveConfig)
         hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
-        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
+        hook.after(Action::UpdateConfig, Action::StartOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_resume) do |hook|
         hook.append(Action::TerminateOrchestration)
         hook.prepend(Action::RemoveConfig)
         hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
-        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
+        hook.after(Action::UpdateConfig, Action::StartOrchestration)
       end
 
       command(:mutagen) do


### PR DESCRIPTION
Hi,

I have attempted to use this plugin (v0.13) on a new project, and it would fail by trying to start orchestration _before_ updating the ssh configuration.

A quick review noted that the following code:
```ruby
hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration)
```
would produce a list like
```ruby
[Vagrant::Action::Builtin::WaitForCommunicator, Action::StartOrchestration, Action::UpdateConfig]
```
instead of the desired list
```ruby
[Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig, Action::StartOrchestration]
```

So I've changed these instances to make the desired ordering more clear/correct.