### PR TITLE
ensure reload & resume correctly order starting/terminating orchestation

### DIFF
--- a/lib/vagrant-mutagen/plugin.rb
+++ b/lib/vagrant-mutagen/plugin.rb
@@ -44,19 +44,19 @@ module VagrantPlugins
 
       action_hook(:mutagen, :machine_action_destroy) do |hook|
         hook.append(Action::TerminateOrchestration)
-        hook.append(Action::RemoveConfig)
+        hook.after(Action::TerminateOrchestration, Action::RemoveConfig)
       end
 
       action_hook(:mutagen, :machine_action_reload) do |hook|
-        hook.append(Action::TerminateOrchestration)
-        hook.prepend(Action::RemoveConfig)
+        hook.prepend(Action::TerminateOrchestration)
+        hook.after(Action::TerminateOrchestration, Action::RemoveConfig)
         hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
         hook.after(Action::UpdateConfig, Action::StartOrchestration)
       end
 
       action_hook(:mutagen, :machine_action_resume) do |hook|
-        hook.append(Action::TerminateOrchestration)
-        hook.prepend(Action::RemoveConfig)
+        hook.prepend(Action::TerminateOrchestration)
+        hook.after(Action::TerminateOrchestration, Action::RemoveConfig)
         hook.after(Vagrant::Action::Builtin::WaitForCommunicator, Action::UpdateConfig)
         hook.after(Action::UpdateConfig, Action::StartOrchestration)
       end


### PR DESCRIPTION
Following on from my last PR ( https://github.com/dasginganinja/vagrant-mutagen/pull/12 )

Had some of my team notice that suspend/resume and reload would result in mutagen stopping.

The isssue was that `Action::TerminateOrchestration` was being appended  so the action sequence appeared to be
  `RemoveConfig` -> ... -> `UpdateConfig` -> `StartOrchestration` -> ... -> `TerminateOrchestration`

This PR makes it so we always `TerminateOrchestration` -> `RemoveConfig` at the start of these actions.


We have been using this for some time, but only recently realised we had not sent this upstream! 